### PR TITLE
pick up

### DIFF
--- a/chop_log/scripts/sun.gd
+++ b/chop_log/scripts/sun.gd
@@ -1,17 +1,27 @@
 extends DirectionalLight3D
 
-@export var x: float
-@export var y: float
+@export var cur: float
+@export var t: float
+@onready var sky: WorldEnvironment = $"../WorldEnvironment"
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 
-	var day_speed = 200.0
+	var day_speed = 30.0
 
 	var ticks = Time.get_ticks_msec() * 0.1
 
-	var t = ( int( ticks ) ) / day_speed
+	var y = ( int( ticks ) ) / day_speed
+	cur = y - 180
+	t = ( int(y+30) % int(360.0) )
 
-	rotation.x = deg_to_rad(t-180)
+	if t >= 0:
+		var fuh = t / 30
+		fuh = clampf(fuh, 0.0, 1.0)
+		
+		var uhf = (t - 360)/30
+		uhf = clampf(uhf, 0.0, 1.0)
+		
+		sky.environment.background_energy_multiplier = fuh
 
-
+	rotation.x = deg_to_rad( cur )

--- a/common/character.tscn
+++ b/common/character.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://c3w863swgslqe"]
+[gd_scene load_steps=13 format=3 uid="uid://c3w863swgslqe"]
 
 [ext_resource type="Script" path="res://common/scripts/character_controller.gd" id="1_tnlc5"]
 [ext_resource type="PackedScene" uid="uid://vuokdfgdnucn" path="res://common/pause_menu.tscn" id="2_q2khm"]
 [ext_resource type="AudioStream" uid="uid://boqdx7can14oq" path="res://audio/grasswalk.ogg" id="3_0mvly"]
+[ext_resource type="Script" path="res://common/debug_screen.gd" id="3_enis5"]
 [ext_resource type="PackedScene" uid="uid://c6l2txqlf73ce" path="res://common/axe.tscn" id="3_md8f2"]
 [ext_resource type="Script" path="res://common/scripts/GrabComponent.gd" id="4_pq1qa"]
 
@@ -60,6 +61,37 @@ mesh = SubResource("CapsuleMesh_5q0gg")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.7, 0)
+
+[node name="DebugVal" type="Control" parent="Camera3D"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("3_enis5")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Camera3D/DebugVal"]
+layout_mode = 1
+anchors_preset = 9
+anchor_bottom = 1.0
+offset_right = 576.0
+grow_vertical = 2
+
+[node name="Transform" type="Label" parent="Camera3D/DebugVal/VBoxContainer"]
+layout_mode = 2
+
+[node name="x" type="Label" parent="Camera3D/DebugVal/VBoxContainer"]
+layout_mode = 2
+
+[node name="y" type="Label" parent="Camera3D/DebugVal/VBoxContainer"]
+layout_mode = 2
+
+[node name="z" type="Label" parent="Camera3D/DebugVal/VBoxContainer"]
+layout_mode = 2
+
+[node name="direction" type="Label" parent="Camera3D/DebugVal/VBoxContainer"]
+layout_mode = 2
 
 [node name="PauseMenu" parent="Camera3D" instance=ExtResource("2_q2khm")]
 visible = false

--- a/common/character.tscn
+++ b/common/character.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=11 format=3 uid="uid://c3w863swgslqe"]
+[gd_scene load_steps=12 format=3 uid="uid://c3w863swgslqe"]
 
 [ext_resource type="Script" path="res://common/scripts/character_controller.gd" id="1_tnlc5"]
 [ext_resource type="PackedScene" uid="uid://vuokdfgdnucn" path="res://common/pause_menu.tscn" id="2_q2khm"]
 [ext_resource type="AudioStream" uid="uid://boqdx7can14oq" path="res://audio/grasswalk.ogg" id="3_0mvly"]
 [ext_resource type="PackedScene" uid="uid://c6l2txqlf73ce" path="res://common/axe.tscn" id="3_md8f2"]
+[ext_resource type="Script" path="res://common/scripts/GrabComponent.gd" id="4_pq1qa"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_61hv6"]
 
@@ -83,6 +84,14 @@ mesh = SubResource("QuadMesh_uv4ub")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Camera3D/Slicer/Area3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.264781, 0.0270138, 0.000354409)
 shape = SubResource("BoxShape3D_iqr4d")
+
+[node name="GrabComponent" type="Node3D" parent="Camera3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.485)
+script = ExtResource("4_pq1qa")
+
+[node name="RayCast3D" type="RayCast3D" parent="Camera3D/GrabComponent"]
+target_position = Vector3(0, 0, -2)
+hit_from_inside = true
 
 [node name="Audios" type="Node3D" parent="."]
 

--- a/common/debug_screen.gd
+++ b/common/debug_screen.gd
@@ -1,0 +1,40 @@
+extends Control
+
+
+@onready var cam: Camera3D     = $"../Camera3D"
+@onready var ltransform: Label = $"VBoxContainer/Transform"
+@onready var lx: Label         = $"VBoxContainer/x"
+@onready var ly: Label         = $"VBoxContainer/y"
+@onready var lz: Label         = $"VBoxContainer/z"
+@onready var ldirection: Label = $"VBoxContainer/direction"
+
+var x: float     = 0.0
+var y: float     = 0.0
+var z: float     = 0.0
+var y_rot: float = 0.0
+var x_rot: float = 0.0
+
+var trans: Transform3D = Transform3D()
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	cam = get_parent()
+	if not cam:
+		return
+
+	ltransform.text = (
+		str(cam.global_transform)
+	)
+
+	lx.text = str(round(cam.global_position.x * 10) / 10)
+	ly.text = str(round((cam.global_position.y - 1.7) * 10) / 10)
+	lz.text = str(round(cam.global_position.z * 10) / 10)
+	ldirection.text = (
+		str(round(cam.global_rotation_degrees.x * 10) / 10) + ' | ' +
+		str(round(cam.global_rotation_degrees.y * 10) / 10)
+	)

--- a/common/scripts/GrabComponent.gd
+++ b/common/scripts/GrabComponent.gd
@@ -8,7 +8,8 @@ func pickup():
 	# if already holding an object, drop it
 	if current_object:
 		return drop()
-	if not ray_cast.get_collider() is RigidBody3D:
+	var selected_object = ray_cast.get_collider()
+	if not selected_object is RigidBody3D or selected_object.is_freeze_enabled():
 		return
 	# Collect reference for held object
 	current_object = ray_cast.get_collider()

--- a/common/scripts/GrabComponent.gd
+++ b/common/scripts/GrabComponent.gd
@@ -1,0 +1,24 @@
+extends Node3D
+
+@onready var ray_cast: RayCast3D = $RayCast3D
+var current_object: RigidBody3D
+var object_previous_parent: Node3D
+
+func pickup():
+	# if already holding an object, drop it
+	if current_object:
+		return drop()
+	if not ray_cast.get_collider():
+		return
+	# Collect reference for held object
+	current_object = ray_cast.get_collider()
+	object_previous_parent = current_object.get_parent()
+	current_object.reparent(self)
+	current_object.freeze = true
+	current_object.position = position
+
+func drop():
+	current_object.reparent(object_previous_parent)
+	current_object.freeze = false
+	
+	current_object = null

--- a/common/scripts/GrabComponent.gd
+++ b/common/scripts/GrabComponent.gd
@@ -8,7 +8,7 @@ func pickup():
 	# if already holding an object, drop it
 	if current_object:
 		return drop()
-	if not ray_cast.get_collider():
+	if not ray_cast.get_collider() is RigidBody3D:
 		return
 	# Collect reference for held object
 	current_object = ray_cast.get_collider()

--- a/common/scripts/GrabComponent.gd
+++ b/common/scripts/GrabComponent.gd
@@ -16,7 +16,6 @@ func pickup():
 	object_previous_parent = current_object.get_parent()
 	current_object.reparent(self)
 	current_object.freeze = true
-	current_object.position = position
 
 func drop():
 	current_object.reparent(object_previous_parent)

--- a/common/scripts/character_controller.gd
+++ b/common/scripts/character_controller.gd
@@ -2,6 +2,7 @@ extends CharacterBody3D
 
 
 const SPEED = 8.0
+const RAMPUP = 1.0
 const JUMP_VELOCITY = 13
 
 @onready var pause_menu = $Camera3D/PauseMenu
@@ -64,19 +65,19 @@ func _physics_process(delta):
 		var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
 
 		if direction:
-			velocity.x = direction.x * SPEED
-			velocity.z = direction.z * SPEED
+			velocity.x = move_toward(velocity.x, (direction.x * SPEED), RAMPUP)
+			velocity.z = move_toward(velocity.z, (direction.z * SPEED), RAMPUP)
 
 			# Footstep Logic
 			if is_on_floor():
 				walk_animation.play( 'walking' )
 
 		else:
-			velocity.x = move_toward(velocity.x, 0, SPEED)
-			velocity.z = move_toward(velocity.z, 0, SPEED)
+			velocity.x = move_toward(velocity.x, 0, RAMPUP)
+			velocity.z = move_toward(velocity.z, 0, RAMPUP)
 	else:
-		velocity.x = move_toward(velocity.x, 0, SPEED)
-		velocity.z = move_toward(velocity.z, 0, SPEED)
+		velocity.x = move_toward(velocity.x, 0, RAMPUP)
+		velocity.z = move_toward(velocity.z, 0, RAMPUP)
 
 	if position.y < -100:
 		position = Vector3(0, 1, 0)
@@ -177,13 +178,13 @@ func _physics_process(delta):
 					#adjust the rigidbody center of mass
 					body2.center_of_mass = body2.to_local(meshinstance.to_global(calculate_center_of_mass(meshh)))
 
-func _update_camera(delta):
+func _update_camera( delta ):
 	_mouse_rotation.x += _tilt_input * delta
 	_mouse_rotation.y += _rotation_input * delta
 	_mouse_rotation.x = clamp(_mouse_rotation.x, deg_to_rad(-85), deg_to_rad(85))
 
-	_player_rotation = Vector3(0.0, _mouse_rotation.y, 0.0)
-	_camera_rotation = Vector3(_mouse_rotation.x, 0.0, 0.0)
+	_player_rotation = Vector3( 0.0, _mouse_rotation.y, 0.0)
+	_camera_rotation = Vector3( _mouse_rotation.x, 0.0, 0.0)
 
 	$Camera3D.transform.basis = Basis.from_euler(_camera_rotation)
 	$Camera3D.rotation.z = 0.0

--- a/common/scripts/character_controller.gd
+++ b/common/scripts/character_controller.gd
@@ -42,6 +42,10 @@ func _physics_process(delta):
 	# Pick up
 	if Input.is_action_just_pressed("right_mouse"):
 		$Camera3D/GrabComponent.pickup()
+	if Input.is_action_just_released("right_mouse"):
+		$Camera3D/GrabComponent.drop()
+	if Input.is_action_just_pressed("left_mouse"):
+		$Camera3D/GrabComponent.throw()
 		
 	# Add the gravity.
 	if not is_on_floor():

--- a/common/scripts/character_controller.gd
+++ b/common/scripts/character_controller.gd
@@ -39,7 +39,10 @@ func _process(_delta):
 		pause_game()
 
 func _physics_process(delta):
-
+	# Pick up
+	if Input.is_action_just_pressed("right_mouse"):
+		$Camera3D/GrabComponent.pickup()
+		
 	# Add the gravity.
 	if not is_on_floor():
 		velocity.y -= gravity * delta

--- a/project.godot
+++ b/project.godot
@@ -77,6 +77,11 @@ left_mouse={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(123, 7),"global_position":Vector2(127, 48),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
+right_mouse={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 Pause={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)


### PR DESCRIPTION
right-click to pick up Rigid Bodies

Currently, this will pick up all RigidBodies, so you can carry around those trees too.

So we need to add some kinda way to limit what objects can be picked up.
Given this is a design choice that will have a great impact on the project going forward, I think it's important to discuss.

Possible Ideas:
- Check the body's mass before picking it up (only pick up "light" objects)
- Create a class that grabbable objects will inherit from
- Create a "grabbable" [group](https://docs.godotengine.org/en/stable/tutorials/scripting/groups.html)

First one is my fav